### PR TITLE
chore: remove obsolete eslint disable directive

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -26,7 +26,6 @@ interface JoinFamilyData {
  * @param {string} link The sign-in link to send.
  * @return {Promise<void>} A promise that resolves when the email is sent.
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 async function sendInvitationEmail(email: string, link: string): Promise<void> {
   // This is a placeholder. In a real app, you would integrate an email service.
   console.log(`Sending invitation email to ${email} with link: ${link}`);


### PR DESCRIPTION
## Summary
- remove unnecessary eslint-disable directive before `sendInvitationEmail`

## Testing
- `npm --prefix functions run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bdf0f748cc8328a4c06604aceda40c